### PR TITLE
Fix failing unit test for saveFuelSavings action with thunk

### DIFF
--- a/src/actions/fuelSavingsActions.js
+++ b/src/actions/fuelSavingsActions.js
@@ -33,6 +33,8 @@ export function calculateFuelSavings(settings, fieldName, value) {
 export function saveFuelSavings(settings) {
   return function(dispatch) {
     dispatch(saveFuelSavingsRequest());
-    return save(settings).then(results => saveFuelSavingsSuccess(results));
+    return save(settings).then(results =>
+      dispatch(saveFuelSavingsSuccess(results.data))
+    );
   };
 }

--- a/src/actions/fuelSavingsActions.spec.js
+++ b/src/actions/fuelSavingsActions.spec.js
@@ -1,11 +1,11 @@
 import * as actionTypes from "../constants/actionTypes";
 import * as actions from "./fuelSavingsActions";
 import initialState from "../reducers/initialState";
-import axios from "axios";
 import thunk from "redux-thunk";
 import configureMockStore from "redux-mock-store";
 import MockAdapter from "axios-mock-adapter";
 import MockDate from "mockdate";
+import { getAxiosApi } from "../api/fuelSavingsApi";
 import { getFormattedDateTime } from "../utils/dates";
 
 describe("Actions", () => {
@@ -44,27 +44,28 @@ describe("Actions", () => {
       tradePpg: 1,
       milesDriven: 100,
       milesDrivenTimeframe: "week",
-      dateModified: new Date()
+      dateModified: `${new Date()}`
     };
 
     // This sets the mock adapter on the default instance
-    var mock = new MockAdapter(axios);
+    var mock = new MockAdapter(getAxiosApi());
     mock.onPost().reply(201, mockResponse);
 
     const expectedActions = [
       { type: actionTypes.SAVE_FUEL_SAVINGS_REQUEST },
       {
         type: actionTypes.SAVE_FUEL_SAVINGS_SUCCESS,
-        settings: mockResponse
+        settings: mockResponse,
+        dateModified
       }
     ];
 
     const store = mockStore({ fuelSavings: initialState }, expectedActions);
 
-    // return store.dispatch(actions.saveFuelSavings(appState)).then(() => {
-    // return of async action
-    // expect(store.getActions()).toEqual(expectedActions);
-    // });
+    return store.dispatch(actions.saveFuelSavings(appState)).then(() => {
+      // return of async action
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it("should create an action to calculate fuel savings", () => {

--- a/src/api/fuelSavingsApi.js
+++ b/src/api/fuelSavingsApi.js
@@ -5,6 +5,10 @@ var api = axios.create({
   responseType: "json"
 });
 
+export function getAxiosApi() {
+  return api;
+}
+
 export function save(fuelSavings) {
   return api
     .post("fuelSavings", {


### PR DESCRIPTION
Hi @coryhouse,

We didn't have the chance to talk more about this, but I think I managed to fix the issue with the failing action test with thunk on `saveFuelSavings`, hence this PR, if you need to use this example in the future 🙂

So, what I did was:
- Add a missing `dispatch` when calling `saveFuelSavingsSuccess`
- Call saveFuelSavingSuccess with only the data that we are interested in, and not the headers from our response that _axios_ returns (hence the `results.data` instead of `results`)
- In our mockAdapter, call the same _axios_ instance of our `fuelSavingsApi` instead of just importing _axios_ again in our test file. For that, I've created a function inside `api/fuelSavingsApi` to export it.
- Added a missing dateModified value on our `SAVE_FUEL_SAVINGS_SUCCESS` expected action.

I'd love to hear some feedback from you regarding this fix.
Thank you once more for the session in this couple of days! It was wonderful learning top-tips and a lot of advice from you.